### PR TITLE
Updated DocumentService for new VerifyMime Endpoint

### DIFF
--- a/projects/app/src/app/features/documents/index.ts
+++ b/projects/app/src/app/features/documents/index.ts
@@ -1,2 +1,3 @@
 export * from './models';
 export * from './services';
+export * from './view-models';

--- a/projects/app/src/app/features/documents/services/document.service.ts
+++ b/projects/app/src/app/features/documents/services/document.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { environment } from '@app/environments';
 import { AbstractQueryableEntityService } from '@core/services/entity';
 import { Document, DocumentQuery } from '../models';
+import { DocumentMimeType } from '../view-models';
 
 @Injectable()
 export class DocumentService extends AbstractQueryableEntityService<Document, DocumentQuery> {
@@ -11,9 +12,11 @@ export class DocumentService extends AbstractQueryableEntityService<Document, Do
     return `${environment.apiUrl}/Document`;
   }
 
-  public verifyMime(mimeType: string): Observable<boolean> {
-    mimeType = (mimeType ?? '').trim().length === 0 ? 'application/octet-stream' : mimeType;
-    const endpoint = `${this._endpoint}/VerifyMime/${encodeURIComponent(mimeType)}`;
-    return this._http.get<boolean>(endpoint);
+  public verifyMime(model: DocumentMimeType): Observable<boolean> {
+    const mimeType = (model?.mimeType ?? '').trim();
+    model.mimeType = mimeType.length === 0 ? 'application/octet-stream' : mimeType;
+
+    const endpoint = `${this._endpoint}/VerifyMime`;
+    return this._http.post<boolean>(endpoint, model);
   }
 }

--- a/projects/app/src/app/features/documents/view-models/document-mime-type.model.ts
+++ b/projects/app/src/app/features/documents/view-models/document-mime-type.model.ts
@@ -1,0 +1,11 @@
+export interface IDocumentMimeType {
+  mimeType: string | undefined;
+}
+
+export class DocumentMimeType implements IDocumentMimeType {
+  mimeType: string | undefined;
+
+  constructor(mimeType: string | undefined) {
+    this.mimeType = mimeType;
+  }
+}

--- a/projects/app/src/app/features/documents/view-models/index.ts
+++ b/projects/app/src/app/features/documents/view-models/index.ts
@@ -1,0 +1,1 @@
+export * from './document-mime-type.model';

--- a/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-edit/admin-documents-edit.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-edit/admin-documents-edit.component.ts
@@ -3,7 +3,7 @@ import { AbstractControl, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { BehaviorSubject, distinctUntilChanged, map, mergeMap, Observable, Subject, takeUntil } from 'rxjs';
 
-import { Document, DocumentService } from '@app/features';
+import { Document, DocumentMimeType, DocumentService } from '@app/features';
 import { SnackBarService } from '@core/services/snackbar';
 import { convertFile } from '@shared/utils';
 import { IAdminEditView } from '../../../components';
@@ -56,7 +56,7 @@ export class AdminDocumentsEditComponent implements IAdminEditView, OnInit, OnDe
     this.dataControl.valueChanges.pipe(
       takeUntil(this.destroyed),
       distinctUntilChanged(),
-      mergeMap((data: File) => this._documentService.verifyMime(data?.type))
+      mergeMap((data: File) => this._documentService.verifyMime(new DocumentMimeType(data?.type)))
     ).subscribe({
       next: valid => {
         if (!valid) {


### PR DESCRIPTION
In the [copeid-server issue here](https://github.com/KyleStank/copeid-server/issues/18), the VerifyMime endpoint needed to be switched to a POST request with body data. The corresponding client side changes for that issue have been made here.