### PR TITLE
Adjustments to Fetch Data via Pagination API

### DIFF
--- a/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
+++ b/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
@@ -26,6 +26,11 @@
 
   <mat-paginator
     autoPaginator
+    [controlManually]="true"
+    [length]="paginatorLength"
+    [pageIndex]="currentPageIndex"
+    [pageSize]="currentPageSize"
     [pageSizeOptions]="[10, 25, 50]"
+    (page)="paginatorInteracted($event)"
   ></mat-paginator>
 </auto-table>

--- a/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
+++ b/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
@@ -26,7 +26,6 @@
 
   <mat-paginator
     autoPaginator
-    [controlManually]="true"
     [pageSizeOptions]="[10, 25, 50]"
   ></mat-paginator>
 </auto-table>

--- a/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
+++ b/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
@@ -28,8 +28,8 @@
     autoPaginator
     [controlManually]="true"
     [length]="paginatorLength"
-    [pageIndex]="currentPageIndex"
-    [pageSize]="currentPageSize"
+    [pageIndex]="pageIndex"
+    [pageSize]="pageSize"
     [pageSizeOptions]="[10, 25, 50]"
     (page)="paginatorInteracted($event)"
   ></mat-paginator>

--- a/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
+++ b/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
@@ -1,6 +1,9 @@
 <ng-content></ng-content>
 
-<auto-table [data]="selectionData ?? []">
+<auto-table
+  [data]="selectionData ?? []"
+  (sortChange)="sortChange.emit($event)"
+>
   <ng-container autoColumnDef="options" header="" [sortable]="false" *ngIf="!!adminMenuDirective">
     <ng-container *autoDataCellOverride="let cell">
       <button mat-icon-button [disableRipple]="true" [matMenuTriggerFor]="menu" (click)="$event.stopPropagation()">

--- a/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
+++ b/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
@@ -26,6 +26,7 @@
 
   <mat-paginator
     autoPaginator
+    [controlManually]="true"
     [pageSizeOptions]="[10, 25, 50]"
   ></mat-paginator>
 </auto-table>

--- a/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
+++ b/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.html
@@ -24,7 +24,8 @@
 
   <ng-container [autoColumnDef]="column.property" [header]="column.title" *ngFor="let column of columns"></ng-container>
 
-  <ng-container autoPaginator>
-    <mat-paginator [pageSizeOptions]="[10, 25, 50]"></mat-paginator>
-  </ng-container>
+  <mat-paginator
+    autoPaginator
+    [pageSizeOptions]="[10, 25, 50]"
+  ></mat-paginator>
 </auto-table>

--- a/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.ts
+++ b/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.ts
@@ -10,8 +10,9 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { PageEvent } from '@angular/material/paginator';
+import { Sort } from '@angular/material/sort';
 
-import { AutoTableComponent } from '@shared/components/auto-table';
+import { AutoTableComponent, AutoTableItem } from '@shared/components/auto-table';
 import { AdminDataTableMenuDirective } from './admin-data-table-menu.directive';
 
 export interface AdminSelectionItem {
@@ -67,6 +68,9 @@ export class AdminDataTableComponent implements OnChanges {
 
   @Output()
   selected = new EventEmitter<AdminSelectionItem[]>();
+
+  @Output()
+  sortChange = new EventEmitter<Sort>();
 
   ngOnChanges(): void {
     this.data = this.data ?? [];

--- a/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.ts
+++ b/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.ts
@@ -48,16 +48,25 @@ export class AdminDataTableComponent implements OnChanges {
   selectionData: AdminSelectionItem[] = [];
 
   @Input()
+  pageIndex = 0;
+
+  @Input()
   paginatorLength = 0;
+
+  @Input()
+  pageSize = 10;
 
   @Output()
   paged = new EventEmitter<PageEvent>();
 
   @Output()
-  selected = new EventEmitter<AdminSelectionItem[]>();
+  pageIndexChange = new EventEmitter<number>();
 
-  currentPageIndex = 0;
-  currentPageSize = 10;
+  @Output()
+  pageSizeChange = new EventEmitter<number>();
+
+  @Output()
+  selected = new EventEmitter<AdminSelectionItem[]>();
 
   ngOnChanges(): void {
     this.data = this.data ?? [];
@@ -79,8 +88,12 @@ export class AdminDataTableComponent implements OnChanges {
   }
 
   paginatorInteracted(pageEvent: PageEvent): void {
-    this.currentPageIndex = pageEvent.pageIndex;
-    this.currentPageSize = pageEvent.pageSize;
+    this.pageIndex = pageEvent.pageIndex;
+    this.pageIndexChange.emit(this.pageIndex);
+
+    this.pageSize = pageEvent.pageSize;
+    this.pageSizeChange.emit(this.pageSize);
+
     this.paged.emit(pageEvent);
   }
 }

--- a/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.ts
+++ b/projects/app/src/app/pages/admin/common/admin-data-table/admin-data-table.component.ts
@@ -9,6 +9,7 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
+import { PageEvent } from '@angular/material/paginator';
 
 import { AutoTableComponent } from '@shared/components/auto-table';
 import { AdminDataTableMenuDirective } from './admin-data-table-menu.directive';
@@ -40,14 +41,23 @@ export class AdminDataTableComponent implements OnChanges {
   adminMenuDirective?: AdminDataTableMenuDirective;
 
   @Input()
+  columns: AdminColumn[] = [];
+
+  @Input()
   data: any[] | undefined | null = [];
   selectionData: AdminSelectionItem[] = [];
 
   @Input()
-  columns: AdminColumn[] = [];
+  paginatorLength = 0;
+
+  @Output()
+  paged = new EventEmitter<PageEvent>();
 
   @Output()
   selected = new EventEmitter<AdminSelectionItem[]>();
+
+  currentPageIndex = 0;
+  currentPageSize = 10;
 
   ngOnChanges(): void {
     this.data = this.data ?? [];
@@ -66,5 +76,11 @@ export class AdminDataTableComponent implements OnChanges {
   toggleItem(item: AdminSelectionItem): void {
     item.selected = !item.selected;
     this.selected.emit(this.selectionData.filter(x => x.selected));
+  }
+
+  paginatorInteracted(pageEvent: PageEvent): void {
+    this.currentPageIndex = pageEvent.pageIndex;
+    this.currentPageSize = pageEvent.pageSize;
+    this.paged.emit(pageEvent);
   }
 }

--- a/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
   [data]="(contributors$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -33,6 +34,7 @@ export class AdminContributorsManageComponent implements IAdminManageView, OnIni
   pageSize = 10;
   cachedData: Contributor[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -49,7 +51,8 @@ export class AdminContributorsManageComponent implements IAdminManageView, OnIni
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: ['name']
+      orderBy: this.sortDirection === 'asc' ? ['name'] : [],
+      orderByDescending: this.sortDirection === 'desc' ? ['name'] : []
     }).subscribe({
       next: results => this._contributorsSubject.next(results)
     });
@@ -108,6 +111,11 @@ export class AdminContributorsManageComponent implements IAdminManageView, OnIni
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.ts
@@ -3,7 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
-import { Contributor, ContributorService } from '@app/features';
+import { Contributor, ContributorQuery, ContributorService } from '@app/features';
 import { PaginationRequest } from '@core/models/pagination';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
@@ -48,20 +48,20 @@ export class AdminContributorsManageComponent implements IAdminManageView, OnIni
   }
 
   getEntities(refreshCache: boolean = false): void {
-    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache).subscribe({
+    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
+      orderBy: ['name']
+    }).subscribe({
       next: results => this._contributorsSubject.next(results)
     });
   }
 
-  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean): Observable<Contributor[]> {
+  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean, query?: Partial<ContributorQuery>): Observable<Contributor[]> {
     const cachedItems = this.cachedData[pageIndex] ?? [];
     if (!refreshCache && (this.cachedData.length === this.pageCount && cachedItems.length > 0)) {
       return from(cachedItems).pipe(toArray());
     }
 
-    return this._contributorService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), {
-      orderBy: ['name']
-    }).pipe(
+    return this._contributorService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), query).pipe(
       tap(response => {
         this.paginatorLength = response?.count ?? this.paginatorLength;
         this.cachedData = !refreshCache && this.cachedData.length === this.pageCount ? this.cachedData : new Array(this.pageCount).fill([]);

--- a/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.ts
@@ -1,9 +1,10 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, skipWhile, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
 import { Contributor, ContributorService } from '@app/features';
+import { PaginationRequest } from '@core/models/pagination';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
 import { IAdminManageView } from '../../../components';
@@ -27,6 +28,11 @@ export class AdminContributorsManageComponent implements IAdminManageView, OnIni
     { title: 'Description', property: 'description' }
   ];
   selectedItems: any[] = [];
+  paginatorLength = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  cachedData: Contributor[][] = [];
+  get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -41,10 +47,28 @@ export class AdminContributorsManageComponent implements IAdminManageView, OnIni
     this.getEntities();
   }
 
-  getEntities(): void {
-    this._contributorService.getAll({
+  getEntities(refreshCache: boolean = false): void {
+    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache).subscribe({
+      next: results => this._contributorsSubject.next(results)
+    });
+  }
+
+  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean): Observable<Contributor[]> {
+    const cachedItems = this.cachedData[pageIndex] ?? [];
+    if (!refreshCache && (this.cachedData.length === this.pageCount && cachedItems.length > 0)) {
+      return from(cachedItems).pipe(toArray());
+    }
+
+    return this._contributorService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), {
       orderBy: ['name']
-    }).subscribe(this._contributorsSubject.next.bind(this._contributorsSubject));
+    }).pipe(
+      tap(response => {
+        this.paginatorLength = response?.count ?? this.paginatorLength;
+        this.cachedData = !refreshCache && this.cachedData.length === this.pageCount ? this.cachedData : new Array(this.pageCount).fill([]);
+        this.cachedData[pageIndex] = response?.data ?? [];
+      }),
+      map(response => response?.data ?? [])
+    );
   }
 
   editAddItem(model?: Contributor): void {
@@ -77,7 +101,7 @@ export class AdminContributorsManageComponent implements IAdminManageView, OnIni
           models!.forEach(m => {
             if (!!m?.id) {
               this._contributorService.delete(m.id).subscribe({
-                next: () => this.getEntities(),
+                next: () => this.getEntities(true),
                 error: (error: any) => console.error('Error:', error)
               });
             }

--- a/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.html
@@ -1,6 +1,8 @@
 <app-admin-data-table
   [data]="(definitions$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.html
@@ -2,6 +2,8 @@
   [data]="(definitions$ | async) ?? []"
   [columns]="columns"
   [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >

--- a/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.ts
@@ -1,12 +1,12 @@
-import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, map, skipWhile, Subject, takeUntil, tap } from 'rxjs';
+import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
 import { Definition, DefinitionService } from '@app/features';
 import { PaginationRequest } from '@core/models/pagination';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
-import { AdminColumn, AdminDataTableComponent } from '../../../common';
+import { AdminColumn } from '../../../common';
 import { IAdminManageView } from '../../../components';
 
 @Component({
@@ -29,9 +29,10 @@ export class AdminDefinitionsManageComponent implements IAdminManageView, OnInit
   ];
   selectedItems: any[] = [];
   paginatorLength = 0;
-
-  @ViewChild(AdminDataTableComponent, { static: true })
-  adminDataTable!: AdminDataTableComponent;
+  pageIndex = 0;
+  pageSize = 10;
+  cachedData: Definition[][] = [];
+  get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -46,17 +47,28 @@ export class AdminDefinitionsManageComponent implements IAdminManageView, OnInit
     this.getEntities();
   }
 
-  getEntities(): void {
-    this.getPagedEntities(this.adminDataTable.currentPageIndex + 1, this.adminDataTable.currentPageSize);
+  getEntities(refreshCache: boolean = false): void {
+    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache).subscribe({
+      next: results => this._definitionsSubject.next(results)
+    });
   }
 
-  getPagedEntities(pageNumber: number, pageSize: number): void {
-    this._definitionService.getAllPaged(new PaginationRequest(pageNumber, pageSize), {
+  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean): Observable<Definition[]> {
+    const cachedItems = this.cachedData[pageIndex] ?? [];
+    if (!refreshCache && (this.cachedData.length === this.pageCount && cachedItems.length > 0)) {
+      return from(cachedItems).pipe(toArray());
+    }
+
+    return this._definitionService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), {
       orderBy: ['name']
     }).pipe(
-      tap(response => this.paginatorLength = response?.count ?? this.paginatorLength),
+      tap(response => {
+        this.paginatorLength = response?.count ?? this.paginatorLength;
+        this.cachedData = !refreshCache && this.cachedData.length === this.pageCount ? this.cachedData : new Array(this.pageCount).fill([]);
+        this.cachedData[pageIndex] = response?.data ?? [];
+      }),
       map(response => response?.data ?? [])
-    ).subscribe(this._definitionsSubject.next.bind(this._definitionsSubject));
+    );
   }
 
   editAddItem(model?: Definition): void {
@@ -89,7 +101,7 @@ export class AdminDefinitionsManageComponent implements IAdminManageView, OnInit
           models!.forEach(m => {
             if (!!m?.id) {
               this._definitionService.delete(m.id).subscribe({
-                next: () => this.getEntities(),
+                next: () => this.getEntities(true),
                 error: (error: any) => console.error('Error:', error)
               });
             }

--- a/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.ts
@@ -6,7 +6,6 @@ import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, 
 
 import { Definition, DefinitionQuery, DefinitionService } from '@app/features';
 import { PaginationRequest } from '@core/models/pagination';
-import { AutoTableItem } from '@shared/components/auto-table';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
 import { IAdminManageView } from '../../../components';

--- a/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.ts
@@ -3,7 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
-import { Definition, DefinitionService } from '@app/features';
+import { Definition, DefinitionQuery, DefinitionService } from '@app/features';
 import { PaginationRequest } from '@core/models/pagination';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
@@ -48,20 +48,20 @@ export class AdminDefinitionsManageComponent implements IAdminManageView, OnInit
   }
 
   getEntities(refreshCache: boolean = false): void {
-    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache).subscribe({
+    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
+      orderBy: ['name']
+    }).subscribe({
       next: results => this._definitionsSubject.next(results)
     });
   }
 
-  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean): Observable<Definition[]> {
+  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean, query?: Partial<DefinitionQuery>): Observable<Definition[]> {
     const cachedItems = this.cachedData[pageIndex] ?? [];
     if (!refreshCache && (this.cachedData.length === this.pageCount && cachedItems.length > 0)) {
       return from(cachedItems).pipe(toArray());
     }
 
-    return this._definitionService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), {
-      orderBy: ['name']
-    }).pipe(
+    return this._definitionService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), query).pipe(
       tap(response => {
         this.paginatorLength = response?.count ?? this.paginatorLength;
         this.cachedData = !refreshCache && this.cachedData.length === this.pageCount ? this.cachedData : new Array(this.pageCount).fill([]);

--- a/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.ts
@@ -1,10 +1,12 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
 import { Definition, DefinitionQuery, DefinitionService } from '@app/features';
 import { PaginationRequest } from '@core/models/pagination';
+import { AutoTableItem } from '@shared/components/auto-table';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
 import { IAdminManageView } from '../../../components';
@@ -33,6 +35,7 @@ export class AdminDefinitionsManageComponent implements IAdminManageView, OnInit
   pageSize = 10;
   cachedData: Definition[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -49,7 +52,8 @@ export class AdminDefinitionsManageComponent implements IAdminManageView, OnInit
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: ['name']
+      orderBy: this.sortDirection === 'asc' ? ['name'] : [],
+      orderByDescending: this.sortDirection === 'desc' ? ['name'] : []
     }).subscribe({
       next: results => this._definitionsSubject.next(results)
     });
@@ -108,6 +112,11 @@ export class AdminDefinitionsManageComponent implements IAdminManageView, OnInit
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
-  [data]="(definitions$ | async) ?? []"
+  [data]="(documents$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.ts
@@ -3,7 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
-import { Document, DocumentService } from '@app/features';
+import { Document, DocumentQuery, DocumentService } from '@app/features';
 import { PaginationRequest } from '@core/models/pagination';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
@@ -47,20 +47,20 @@ export class AdminDocumentsManageComponent implements IAdminManageView, OnInit, 
   }
 
   getEntities(refreshCache: boolean = false): void {
-    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache).subscribe({
+    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
+      orderBy: ['name']
+    }).subscribe({
       next: results => this._documentsSubject.next(results)
     });
   }
 
-  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean): Observable<Document[]> {
+  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean, query?: Partial<DocumentQuery>): Observable<Document[]> {
     const cachedItems = this.cachedData[pageIndex] ?? [];
     if (!refreshCache && (this.cachedData.length === this.pageCount && cachedItems.length > 0)) {
       return from(cachedItems).pipe(toArray());
     }
 
-    return this._documentService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), {
-      orderBy: ['name']
-    }).pipe(
+    return this._documentService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), query).pipe(
       tap(response => {
         this.paginatorLength = response?.count ?? this.paginatorLength;
         this.cachedData = !refreshCache && this.cachedData.length === this.pageCount ? this.cachedData : new Array(this.pageCount).fill([]);

--- a/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.ts
@@ -1,9 +1,10 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, skipWhile, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
 import { Document, DocumentService } from '@app/features';
+import { PaginationRequest } from '@core/models/pagination';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
 import { IAdminManageView } from '../../../components';
@@ -20,12 +21,17 @@ import { IAdminManageView } from '../../../components';
 export class AdminDocumentsManageComponent implements IAdminManageView, OnInit, OnDestroy {
   readonly destroyed = new Subject<void>();
 
-  private readonly _definitionsSubject = new BehaviorSubject<Document[]>([]);
-  readonly definitions$ = this._definitionsSubject.asObservable();
+  private readonly _documentsSubject = new BehaviorSubject<Document[]>([]);
+  readonly documents$ = this._documentsSubject.asObservable();
   readonly columns: AdminColumn[] = [
     { title: 'Name', property: 'name' }
   ];
   selectedItems: any[] = [];
+  paginatorLength = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  cachedData: Document[][] = [];
+  get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -33,17 +39,35 @@ export class AdminDocumentsManageComponent implements IAdminManageView, OnInit, 
     private readonly _dialog: MatDialog,
     private readonly _router: Router
   ) {
-    this.definitions$ = this.definitions$.pipe(takeUntil(this.destroyed));
+    this.documents$ = this.documents$.pipe(takeUntil(this.destroyed));
   }
 
   ngOnInit(): void {
     this.getEntities();
   }
 
-  getEntities(): void {
-    this._documentService.getAll({
+  getEntities(refreshCache: boolean = false): void {
+    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache).subscribe({
+      next: results => this._documentsSubject.next(results)
+    });
+  }
+
+  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean): Observable<Document[]> {
+    const cachedItems = this.cachedData[pageIndex] ?? [];
+    if (!refreshCache && (this.cachedData.length === this.pageCount && cachedItems.length > 0)) {
+      return from(cachedItems).pipe(toArray());
+    }
+
+    return this._documentService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), {
       orderBy: ['name']
-    }).subscribe(this._definitionsSubject.next.bind(this._definitionsSubject));
+    }).pipe(
+      tap(response => {
+        this.paginatorLength = response?.count ?? this.paginatorLength;
+        this.cachedData = !refreshCache && this.cachedData.length === this.pageCount ? this.cachedData : new Array(this.pageCount).fill([]);
+        this.cachedData[pageIndex] = response?.data ?? [];
+      }),
+      map(response => response?.data ?? [])
+    );
   }
 
   editAddItem(model?: Document): void {
@@ -76,7 +100,7 @@ export class AdminDocumentsManageComponent implements IAdminManageView, OnInit, 
           models!.forEach(m => {
             if (!!m?.id) {
               this._documentService.delete(m.id).subscribe({
-                next: () => this.getEntities(),
+                next: () => this.getEntities(true),
                 error: (error: any) => console.error('Error:', error)
               });
             }

--- a/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -32,6 +33,7 @@ export class AdminDocumentsManageComponent implements IAdminManageView, OnInit, 
   pageSize = 10;
   cachedData: Document[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -48,7 +50,8 @@ export class AdminDocumentsManageComponent implements IAdminManageView, OnInit, 
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: ['name']
+      orderBy: this.sortDirection === 'asc' ? ['name'] : [],
+      orderByDescending: this.sortDirection === 'desc' ? ['name'] : []
     }).subscribe({
       next: results => this._documentsSubject.next(results)
     });
@@ -107,6 +110,11 @@ export class AdminDocumentsManageComponent implements IAdminManageView, OnInit, 
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage-properties/admin-filter-models-manage-properties.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage-properties/admin-filter-models-manage-properties.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage-properties/admin-filter-models-manage-properties.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage-properties/admin-filter-models-manage-properties.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
   [data]="(filterModelProperties$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage-properties/admin-filter-models-manage-properties.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage-properties/admin-filter-models-manage-properties.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -33,6 +34,7 @@ export class AdminFilterModelsManagePropertiesComponent implements IAdminManageV
   pageSize = 10;
   cachedData: FilterModelProperty[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   filterModelId: string | undefined;
 
@@ -54,7 +56,8 @@ export class AdminFilterModelsManagePropertiesComponent implements IAdminManageV
     if (!!this.filterModelId) {
       this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
         filterModelId: [this.filterModelId],
-        orderBy: ['propertyName']
+        orderBy: this.sortDirection === 'asc' ? ['propertyName'] : [],
+        orderByDescending: this.sortDirection === 'desc' ? ['propertyName'] : []
       }).subscribe({
         next: results => this._filterModelPropertiesSubject.next(results)
       });
@@ -111,6 +114,11 @@ export class AdminFilterModelsManagePropertiesComponent implements IAdminManageV
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage/admin-filter-models-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage/admin-filter-models-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage/admin-filter-models-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage/admin-filter-models-manage.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
   [data]="(filterModels$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage/admin-filter-models-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage/admin-filter-models-manage.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -32,6 +33,7 @@ export class AdminFilterModelsManageComponent implements IAdminManageView, OnIni
   pageSize = 10;
   cachedData: FilterModel[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -48,7 +50,8 @@ export class AdminFilterModelsManageComponent implements IAdminManageView, OnIni
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: ['typeName']
+      orderBy: this.sortDirection === 'asc' ? ['typeName'] : [],
+      orderByDescending: this.sortDirection === 'desc' ? ['typeName'] : []
     }).subscribe({
       next: results => this._filterModelsSubject.next(results)
     });
@@ -108,6 +111,11 @@ export class AdminFilterModelsManageComponent implements IAdminManageView, OnIni
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage/admin-filter-models-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage/admin-filter-models-manage.component.ts
@@ -1,9 +1,10 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, skipWhile, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
-import { FilterModel, FilterModelService } from '@app/features';
+import { FilterModel, FilterModelQuery, FilterModelService } from '@app/features';
+import { PaginationRequest } from '@core/models/pagination';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
 import { IAdminManageView } from '../../../components';
@@ -26,6 +27,11 @@ export class AdminFilterModelsManageComponent implements IAdminManageView, OnIni
     { title: 'Type Name', property: 'typeName' }
   ];
   selectedItems: any[] = [];
+  paginatorLength = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  cachedData: FilterModel[][] = [];
+  get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -40,10 +46,28 @@ export class AdminFilterModelsManageComponent implements IAdminManageView, OnIni
     this.getEntities();
   }
 
-  getEntities(): void {
-    this._filterModelService.getAll({
+  getEntities(refreshCache: boolean = false): void {
+    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
       orderBy: ['typeName']
-    }).subscribe(this._filterModelsSubject.next.bind(this._filterModelsSubject));
+    }).subscribe({
+      next: results => this._filterModelsSubject.next(results)
+    });
+  }
+
+  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean, query?: Partial<FilterModelQuery>): Observable<FilterModel[]> {
+    const cachedItems = this.cachedData[pageIndex] ?? [];
+    if (!refreshCache && (this.cachedData.length === this.pageCount && cachedItems.length > 0)) {
+      return from(cachedItems).pipe(toArray());
+    }
+
+    return this._filterModelService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), query).pipe(
+      tap(response => {
+        this.paginatorLength = response?.count ?? this.paginatorLength;
+        this.cachedData = !refreshCache && this.cachedData.length === this.pageCount ? this.cachedData : new Array(this.pageCount).fill([]);
+        this.cachedData[pageIndex] = response?.data ?? [];
+      }),
+      map(response => response?.data ?? [])
+    );
   }
 
   editAddItem(model?: FilterModel): void {
@@ -77,7 +101,7 @@ export class AdminFilterModelsManageComponent implements IAdminManageView, OnIni
           models!.forEach(m => {
             if (!!m?.id) {
               this._filterModelService.delete(m.id).subscribe({
-                next: () => this.getEntities(),
+                next: () => this.getEntities(true),
                 error: (error: any) => console.error('Error:', error)
               });
             }

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-manage/admin-filter-sections-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-manage/admin-filter-sections-manage.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
   [data]="(filterSections$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-manage/admin-filter-sections-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-manage/admin-filter-sections-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-manage/admin-filter-sections-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-manage/admin-filter-sections-manage.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -35,6 +36,7 @@ export class AdminFiltersSectionsManageComponent implements IAdminManageView, On
   pageSize = 10;
   cachedData: FilterSection[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   filterId: string | undefined;
 
@@ -56,7 +58,8 @@ export class AdminFiltersSectionsManageComponent implements IAdminManageView, On
     if (!!this.filterId) {
       this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
         filterId: [this.filterId],
-        orderBy: ['order']
+        orderBy: this.sortDirection === 'asc' ? ['order'] : [],
+        orderByDescending: this.sortDirection === 'desc' ? ['order'] : []
       }).subscribe({
         next: results => this._filterSectionsSubject.next(results)
       });
@@ -117,6 +120,11 @@ export class AdminFiltersSectionsManageComponent implements IAdminManageView, On
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-manage/admin-filter-sections-parts-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-manage/admin-filter-sections-parts-manage.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
   [data]="(filterSectionParts$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-manage/admin-filter-sections-parts-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-manage/admin-filter-sections-parts-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-manage/admin-filter-sections-parts-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-manage/admin-filter-sections-parts-manage.component.ts
@@ -1,9 +1,10 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, skipWhile, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
-import { FilterSectionPart, FilterSectionPartService } from '@app/features';
+import { FilterSectionPart, FilterSectionPartQuery, FilterSectionPartService } from '@app/features';
+import { PaginationRequest } from '@core/models/pagination';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
 import { IAdminManageView } from '../../../components';
@@ -29,6 +30,11 @@ export class AdminFiltersSectionsPartsManageComponent implements IAdminManageVie
     { title: 'Order', property: 'order' }
   ];
   selectedItems: any[] = [];
+  paginatorLength = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  cachedData: FilterSectionPart[][] = [];
+  get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
 
   filterSectionId: string | undefined;
 
@@ -45,15 +51,33 @@ export class AdminFiltersSectionsPartsManageComponent implements IAdminManageVie
     this.getEntities();
   }
 
-  getEntities(): void {
+  getEntities(refreshCache: boolean = false): void {
     this.filterSectionId = this._activatedRoute.snapshot.paramMap.get('filterSectionId') ?? undefined;
     if (!!this.filterSectionId) {
-      this._filterSectionPartService.getAll({
+      this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
         filterSectionId: [this.filterSectionId],
         include: ['filterModelProperty'],
         orderBy: ['order']
-      }).subscribe(this._filterSectionPartsSubject.next.bind(this._filterSectionPartsSubject));
+      }).subscribe({
+        next: results => this._filterSectionPartsSubject.next(results)
+      });
     }
+  }
+
+  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean, query?: Partial<FilterSectionPartQuery>): Observable<FilterSectionPart[]> {
+    const cachedItems = this.cachedData[pageIndex] ?? [];
+    if (!refreshCache && (this.cachedData.length === this.pageCount && cachedItems.length > 0)) {
+      return from(cachedItems).pipe(toArray());
+    }
+
+    return this._filterSectionPartService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), query).pipe(
+      tap(response => {
+        this.paginatorLength = response?.count ?? this.paginatorLength;
+        this.cachedData = !refreshCache && this.cachedData.length === this.pageCount ? this.cachedData : new Array(this.pageCount).fill([]);
+        this.cachedData[pageIndex] = response?.data ?? [];
+      }),
+      map(response => response?.data ?? [])
+    );
   }
 
   editAddItem(model?: FilterSectionPart): void {
@@ -87,7 +111,7 @@ export class AdminFiltersSectionsPartsManageComponent implements IAdminManageVie
           models!.forEach(m => {
             if (!!m?.id) {
               this._filterSectionPartService.delete(m.id).subscribe({
-                next: () => this.getEntities(),
+                next: () => this.getEntities(true),
                 error: (error: any) => console.error('Error:', error)
               });
             }

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-manage/admin-filter-sections-parts-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-manage/admin-filter-sections-parts-manage.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -35,6 +36,7 @@ export class AdminFiltersSectionsPartsManageComponent implements IAdminManageVie
   pageSize = 10;
   cachedData: FilterSectionPart[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   filterSectionId: string | undefined;
 
@@ -57,7 +59,8 @@ export class AdminFiltersSectionsPartsManageComponent implements IAdminManageVie
       this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
         filterSectionId: [this.filterSectionId],
         include: ['filterModelProperty'],
-        orderBy: ['order']
+        orderBy: this.sortDirection === 'asc' ? ['order'] : [],
+        orderByDescending: this.sortDirection === 'desc' ? ['order'] : []
       }).subscribe({
         next: results => this._filterSectionPartsSubject.next(results)
       });
@@ -118,6 +121,11 @@ export class AdminFiltersSectionsPartsManageComponent implements IAdminManageVie
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-options-manage/admin-filter-sections-parts-options-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-options-manage/admin-filter-sections-parts-options-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-options-manage/admin-filter-sections-parts-options-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-options-manage/admin-filter-sections-parts-options-manage.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
   [data]="(filterSectionPartOptions$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-options-manage/admin-filter-sections-parts-options-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-options-manage/admin-filter-sections-parts-options-manage.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -36,6 +37,7 @@ export class AdminFiltersSectionsPartsOptionsManageComponent implements IAdminMa
   pageSize = 10;
   cachedData: FilterSectionPartOption[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   filterSectionPartId: string | undefined;
 
@@ -57,7 +59,8 @@ export class AdminFiltersSectionsPartsOptionsManageComponent implements IAdminMa
     if (!!this.filterSectionPartId) {
       this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
         filterSectionPartId: [this.filterSectionPartId],
-        orderBy: ['order']
+        orderBy: this.sortDirection === 'asc' ? ['order'] : [],
+        orderByDescending: this.sortDirection === 'desc' ? ['order'] : []
       }).subscribe({
         next: results => this._filterSectionPartOptionsSubject.next(results)
       });
@@ -114,6 +117,11 @@ export class AdminFiltersSectionsPartsOptionsManageComponent implements IAdminMa
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filters-manage/admin-filters-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filters-manage/admin-filters-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filters-manage/admin-filters-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filters-manage/admin-filters-manage.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
   [data]="(filters$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filters-manage/admin-filters-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filters-manage/admin-filters-manage.component.ts
@@ -1,9 +1,10 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, skipWhile, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
-import { Filter, FilterService } from '@app/features';
+import { Filter, FilterQuery, FilterService } from '@app/features';
+import { PaginationRequest } from '@core/models/pagination';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
 import { IAdminManageView } from '../../../components';
@@ -27,6 +28,11 @@ export class AdminFiltersManageComponent implements IAdminManageView, OnInit, On
     { title: 'Filter Model', property: 'filterModel.typeName' }
   ];
   selectedItems: any[] = [];
+  paginatorLength = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  cachedData: Filter[][] = [];
+  get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -41,11 +47,29 @@ export class AdminFiltersManageComponent implements IAdminManageView, OnInit, On
     this.getEntities();
   }
 
-  getEntities(): void {
-    this._filterService.getAll({
+  getEntities(refreshCache: boolean = false): void {
+    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
       include: ['filterModel'],
       orderBy: ['displayName']
-    }).subscribe(this._filtersSubject.next.bind(this._filtersSubject));
+    }).subscribe({
+      next: results => this._filtersSubject.next(results)
+    });
+  }
+
+  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean, query?: Partial<FilterQuery>): Observable<Filter[]> {
+    const cachedItems = this.cachedData[pageIndex] ?? [];
+    if (!refreshCache && (this.cachedData.length === this.pageCount && cachedItems.length > 0)) {
+      return from(cachedItems).pipe(toArray());
+    }
+
+    return this._filterService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), query).pipe(
+      tap(response => {
+        this.paginatorLength = response?.count ?? this.paginatorLength;
+        this.cachedData = !refreshCache && this.cachedData.length === this.pageCount ? this.cachedData : new Array(this.pageCount).fill([]);
+        this.cachedData[pageIndex] = response?.data ?? [];
+      }),
+      map(response => response?.data ?? [])
+    );
   }
 
   editAddItem(model?: Filter): void {
@@ -79,7 +103,7 @@ export class AdminFiltersManageComponent implements IAdminManageView, OnInit, On
           models!.forEach(m => {
             if (!!m?.id) {
               this._filterService.delete(m.id).subscribe({
-                next: () => this.getEntities(),
+                next: () => this.getEntities(true),
                 error: (error: any) => console.error('Error:', error)
               });
             }

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filters-manage/admin-filters-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filters-manage/admin-filters-manage.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -33,6 +34,7 @@ export class AdminFiltersManageComponent implements IAdminManageView, OnInit, On
   pageSize = 10;
   cachedData: Filter[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -50,7 +52,8 @@ export class AdminFiltersManageComponent implements IAdminManageView, OnInit, On
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
       include: ['filterModel'],
-      orderBy: ['displayName']
+      orderBy: this.sortDirection === 'asc' ? ['displayName'] : [],
+        orderByDescending: this.sortDirection === 'desc' ? ['displayName'] : []
     }).subscribe({
       next: results => this._filtersSubject.next(results)
     });
@@ -110,6 +113,11 @@ export class AdminFiltersManageComponent implements IAdminManageView, OnInit, On
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-genuses/admin-genuses-manage/admin-genuses-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-genuses/admin-genuses-manage/admin-genuses-manage.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
   [data]="(genuses$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-genuses/admin-genuses-manage/admin-genuses-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-genuses/admin-genuses-manage/admin-genuses-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-genuses/admin-genuses-manage/admin-genuses-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-genuses/admin-genuses-manage/admin-genuses-manage.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -32,6 +33,7 @@ export class AdminGenusesManageComponent implements IAdminManageView, OnInit, On
   pageSize = 10;
   cachedData: Genus[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -49,7 +51,8 @@ export class AdminGenusesManageComponent implements IAdminManageView, OnInit, On
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
       include: ['photograph', 'specimens'],
-      orderBy: ['name']
+      orderBy: this.sortDirection === 'asc' ? ['name'] : [],
+      orderByDescending: this.sortDirection === 'desc' ? ['name'] : []
     }).subscribe({
       next: results => this._genusesSubject.next(results)
     });
@@ -108,6 +111,11 @@ export class AdminGenusesManageComponent implements IAdminManageView, OnInit, On
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-photographs/admin-photographs-manage/admin-photographs-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-photographs/admin-photographs-manage/admin-photographs-manage.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
   [data]="(photographs$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-photographs/admin-photographs-manage/admin-photographs-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-photographs/admin-photographs-manage/admin-photographs-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-photographs/admin-photographs-manage/admin-photographs-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-photographs/admin-photographs-manage/admin-photographs-manage.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -35,6 +36,7 @@ export class AdminPhotographsManageComponent implements IAdminManageView, OnInit
   pageSize = 10;
   cachedData: Photograph[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -51,7 +53,8 @@ export class AdminPhotographsManageComponent implements IAdminManageView, OnInit
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: ['title']
+      orderBy: this.sortDirection === 'asc' ? ['title'] : [],
+      orderByDescending: this.sortDirection === 'desc' ? ['title'] : []
     }).subscribe({
       next: results => this._photographsSubject.next(results)
     });
@@ -110,6 +113,11 @@ export class AdminPhotographsManageComponent implements IAdminManageView, OnInit
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
   [data]="(references$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -32,6 +33,7 @@ export class AdminReferencesManageComponent implements IAdminManageView, OnInit,
   pageSize = 10;
   cachedData: Reference[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -48,7 +50,8 @@ export class AdminReferencesManageComponent implements IAdminManageView, OnInit,
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: ['name']
+      orderBy: this.sortDirection === 'asc' ? ['name'] : [],
+      orderByDescending: this.sortDirection === 'desc' ? ['name'] : []
     }).subscribe({
       next: results => this._referencesSubject.next(results)
     });
@@ -107,6 +110,11 @@ export class AdminReferencesManageComponent implements IAdminManageView, OnInit,
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.ts
@@ -50,8 +50,8 @@ export class AdminReferencesManageComponent implements IAdminManageView, OnInit,
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: this.sortDirection === 'asc' ? ['name'] : [],
-      orderByDescending: this.sortDirection === 'desc' ? ['name'] : []
+      orderBy: this.sortDirection === 'asc' ? ['content'] : [],
+      orderByDescending: this.sortDirection === 'desc' ? ['content'] : []
     }).subscribe({
       next: results => this._referencesSubject.next(results)
     });

--- a/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.ts
@@ -1,9 +1,10 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, skipWhile, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
-import { Reference, ReferenceService } from '@app/features';
+import { Reference, ReferenceQuery, ReferenceService } from '@app/features';
+import { PaginationRequest } from '@core/models/pagination';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
 import { IAdminManageView } from '../../../components';
@@ -26,6 +27,11 @@ export class AdminReferencesManageComponent implements IAdminManageView, OnInit,
     { title: 'Content', property: 'content' }
   ];
   selectedItems: any[] = [];
+  paginatorLength = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  cachedData: Reference[][] = [];
+  get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -40,10 +46,28 @@ export class AdminReferencesManageComponent implements IAdminManageView, OnInit,
     this.getEntities();
   }
 
-  getEntities(): void {
-    this._referenceService.getAll({
+  getEntities(refreshCache: boolean = false): void {
+    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
       orderBy: ['name']
-    }).subscribe(this._referencesSubject.next.bind(this._referencesSubject));
+    }).subscribe({
+      next: results => this._referencesSubject.next(results)
+    });
+  }
+
+  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean, query?: Partial<ReferenceQuery>): Observable<Reference[]> {
+    const cachedItems = this.cachedData[pageIndex] ?? [];
+    if (!refreshCache && (this.cachedData.length === this.pageCount && cachedItems.length > 0)) {
+      return from(cachedItems).pipe(toArray());
+    }
+
+    return this._referenceService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), query).pipe(
+      tap(response => {
+        this.paginatorLength = response?.count ?? this.paginatorLength;
+        this.cachedData = !refreshCache && this.cachedData.length === this.pageCount ? this.cachedData : new Array(this.pageCount).fill([]);
+        this.cachedData[pageIndex] = response?.data ?? [];
+      }),
+      map(response => response?.data ?? [])
+    );
   }
 
   editAddItem(model?: Reference): void {
@@ -76,7 +100,7 @@ export class AdminReferencesManageComponent implements IAdminManageView, OnInit,
           models!.forEach(m => {
             if (!!m?.id) {
               this._referenceService.delete(m.id).subscribe({
-                next: () => this.getEntities(),
+                next: () => this.getEntities(true),
                 error: (error: any) => console.error('Error:', error)
               });
             }

--- a/projects/app/src/app/pages/admin/pages/admin-specimens/admin-specimens-manage/admin-specimens-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-specimens/admin-specimens-manage/admin-specimens-manage.component.html
@@ -6,6 +6,7 @@
   [(pageSize)]="pageSize"
   (paged)="getEntities()"
   (selected)="selectedItems = $event"
+  (sortChange)="sortChange($event)"
 >
   <ng-container *adminDataTableMenu="let cell">
     <button mat-menu-item (click)="editAddItem(cell)">

--- a/projects/app/src/app/pages/admin/pages/admin-specimens/admin-specimens-manage/admin-specimens-manage.component.html
+++ b/projects/app/src/app/pages/admin/pages/admin-specimens/admin-specimens-manage/admin-specimens-manage.component.html
@@ -1,6 +1,10 @@
 <app-admin-data-table
   [data]="(specimens$ | async) ?? []"
   [columns]="columns"
+  [paginatorLength]="paginatorLength"
+  [(pageIndex)]="pageIndex"
+  [(pageSize)]="pageSize"
+  (paged)="getEntities()"
   (selected)="selectedItems = $event"
 >
   <ng-container *adminDataTableMenu="let cell">

--- a/projects/app/src/app/pages/admin/pages/admin-specimens/admin-specimens-manage/admin-specimens-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-specimens/admin-specimens-manage/admin-specimens-manage.component.ts
@@ -1,9 +1,10 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, skipWhile, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
-import { Specimen, SpecimenService } from '@app/features';
+import { Specimen, SpecimenQuery, SpecimenService } from '@app/features';
+import { PaginationRequest } from '@core/models/pagination';
 import { ConfirmationAlertModalCompoonent } from '@shared/modals/confirmation-alert';
 import { AdminColumn } from '../../../common';
 import { IAdminManageView } from '../../../components';
@@ -26,6 +27,11 @@ export class AdminSpecimensManageComponent implements IAdminManageView, OnInit, 
     { title: 'Name', property: 'genus.name' }
   ];
   selectedItems: any[] = [];
+  paginatorLength = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  cachedData: Specimen[][] = [];
+  get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -40,11 +46,29 @@ export class AdminSpecimensManageComponent implements IAdminManageView, OnInit, 
     this.getEntities();
   }
 
-  getEntities(): void {
-    this._specimenService.getAll({
+  getEntities(refreshCache: boolean = false): void {
+    this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
       orderBy: ['genus.name'],
       include: ['genus', 'photograph']
-    }).subscribe(this._specimensSubject.next.bind(this._specimensSubject));
+    }).subscribe({
+      next: results => this._specimensSubject.next(results)
+    });
+  }
+
+  private _getPagedEntities$(pageIndex: number, pageSize: number, refreshCache: boolean, query?: Partial<SpecimenQuery>): Observable<Specimen[]> {
+    const cachedItems = this.cachedData[pageIndex] ?? [];
+    if (!refreshCache && (this.cachedData.length === this.pageCount && cachedItems.length > 0)) {
+      return from(cachedItems).pipe(toArray());
+    }
+
+    return this._specimenService.getAllPaged(new PaginationRequest(pageIndex + 1, pageSize), query).pipe(
+      tap(response => {
+        this.paginatorLength = response?.count ?? this.paginatorLength;
+        this.cachedData = !refreshCache && this.cachedData.length === this.pageCount ? this.cachedData : new Array(this.pageCount).fill([]);
+        this.cachedData[pageIndex] = response?.data ?? [];
+      }),
+      map(response => response?.data ?? [])
+    );
   }
 
   editAddItem(model?: Specimen): void {
@@ -77,7 +101,7 @@ export class AdminSpecimensManageComponent implements IAdminManageView, OnInit, 
           models!.forEach(m => {
             if (!!m?.id) {
               this._specimenService.delete(m.id).subscribe({
-                next: () => this.getEntities(),
+                next: () => this.getEntities(true),
                 error: (error: any) => console.error('Error:', error)
               });
             }

--- a/projects/app/src/app/pages/admin/pages/admin-specimens/admin-specimens-manage/admin-specimens-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-specimens/admin-specimens-manage/admin-specimens-manage.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Sort } from '@angular/material/sort';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject, from, map, Observable, skipWhile, Subject, takeUntil, tap, toArray } from 'rxjs';
 
@@ -32,6 +33,7 @@ export class AdminSpecimensManageComponent implements IAdminManageView, OnInit, 
   pageSize = 10;
   cachedData: Specimen[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
+  sortDirection: 'asc' | 'desc' | undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -48,8 +50,9 @@ export class AdminSpecimensManageComponent implements IAdminManageView, OnInit, 
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: ['genus.name'],
-      include: ['genus', 'photograph']
+      include: ['genus', 'photograph'],
+      orderBy: this.sortDirection === 'asc' ? ['genus.name'] : [],
+      orderByDescending: this.sortDirection === 'desc' ? ['genus.name'] : []
     }).subscribe({
       next: results => this._specimensSubject.next(results)
     });
@@ -108,6 +111,11 @@ export class AdminSpecimensManageComponent implements IAdminManageView, OnInit, 
           });
         }
       });
+  }
+
+  sortChange(sort: Sort): void {
+    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.getEntities(true);
   }
 
   ngOnDestroy(): void {

--- a/projects/core/models/pagination/index.ts
+++ b/projects/core/models/pagination/index.ts
@@ -1,0 +1,1 @@
+export * from './public-api';

--- a/projects/core/models/pagination/package.json
+++ b/projects/core/models/pagination/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@core/models/pagination",
+  "version": "0.0.1",
+  "dependencies": {
+    "tslib": "^2.1.0"
+  },
+  "ngPackage": {
+    "lib": {
+      "entryFile": "index.ts",
+      "styleIncludePaths": ["../../../app/src/styles"]
+    }
+  }
+}

--- a/projects/core/models/pagination/pagination-request.model.ts
+++ b/projects/core/models/pagination/pagination-request.model.ts
@@ -1,0 +1,9 @@
+export class PaginationRequest {
+  pageNumber: number;
+  pageSize: number;
+
+  constructor(pageNumber: number, pageSize: number) {
+    this.pageNumber = Math.max(1, pageNumber);
+    this.pageSize = pageSize;
+  }
+}

--- a/projects/core/models/pagination/pagination-response.model.ts
+++ b/projects/core/models/pagination/pagination-response.model.ts
@@ -1,0 +1,9 @@
+export class PaginationResponse<T> {
+  count: number;
+  data: T[];
+
+  constructor(count: number, data: T[]) {
+    this.count = count;
+    this.data = data;
+  }
+}

--- a/projects/core/models/pagination/public-api.ts
+++ b/projects/core/models/pagination/public-api.ts
@@ -1,0 +1,2 @@
+export * from './pagination-request.model';
+export * from './pagination-response.model';

--- a/projects/core/services/entity/abstract.entity.service.ts
+++ b/projects/core/services/entity/abstract.entity.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { IEntity } from '@core/models/entity';
-import { PaginationRequest } from '@core/models/pagination';
+import { PaginationRequest, PaginationResponse } from '@core/models/pagination';
 
 @Injectable()
 export abstract class AbstractEntityService<TEntity = IEntity> {
@@ -16,11 +16,14 @@ export abstract class AbstractEntityService<TEntity = IEntity> {
 
   public abstract getEndpoint(): string;
 
-  public getAll(paginationRequest?: PaginationRequest): Observable<TEntity[]> {
+  public getAll(): Observable<TEntity[]> {
     const endpoint = this._endpoint;
-    return this._http.get<TEntity[]>(
-      paginationRequest ? this._createQueryEndpoint(endpoint, paginationRequest) : endpoint
-    );
+    return this._http.get<TEntity[]>(endpoint);
+  }
+
+  public getAllPaged(paginationRequest: PaginationRequest): Observable<PaginationResponse<TEntity>> {
+    const endpoint = this._endpoint;
+    return this._http.get<PaginationResponse<TEntity>>(this._createQueryEndpoint(endpoint, paginationRequest));
   }
 
   public getSingle(id: string): Observable<TEntity> {

--- a/projects/core/services/entity/abstract.queryable-entity.service.ts
+++ b/projects/core/services/entity/abstract.queryable-entity.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { IEntity, IEntityQuery } from '@core/models/entity';
+import { PaginationRequest } from '@core/models/pagination';
 
 @Injectable()
 export abstract class AbstractQueryableEntityService<TEntity = IEntity, TQuery = IEntityQuery> {
@@ -15,7 +16,7 @@ export abstract class AbstractQueryableEntityService<TEntity = IEntity, TQuery =
 
   public abstract getEndpoint(): string;
 
-  public getAll(query?: Partial<TQuery>): Observable<TEntity[]> {
+  public getAll(query?: Partial<TQuery> | PaginationRequest): Observable<TEntity[]> {
     const endpoint = this._endpoint;
     return this._http.get<TEntity[]>(
       query ? this._createQueryEndpoint(endpoint, query) : endpoint
@@ -50,7 +51,7 @@ export abstract class AbstractQueryableEntityService<TEntity = IEntity, TQuery =
     return this._http.delete<string>(endpoint);
   }
 
-  protected _createQueryEndpoint(endpoint: string, query: Partial<TQuery>): string {
+  protected _createQueryEndpoint(endpoint: string, query: Object): string {
     const params: KeyValue<string, string>[] = [];
     Object.keys(query).forEach(key => {
       const value = (query as any)[key];

--- a/projects/core/services/entity/abstract.queryable-entity.service.ts
+++ b/projects/core/services/entity/abstract.queryable-entity.service.ts
@@ -1,10 +1,11 @@
 import { KeyValue } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { merge } from 'lodash';
 import { Observable } from 'rxjs';
 
 import { IEntity, IEntityQuery } from '@core/models/entity';
-import { PaginationRequest } from '@core/models/pagination';
+import { PaginationRequest, PaginationResponse } from '@core/models/pagination';
 
 @Injectable()
 export abstract class AbstractQueryableEntityService<TEntity = IEntity, TQuery = IEntityQuery> {
@@ -16,11 +17,17 @@ export abstract class AbstractQueryableEntityService<TEntity = IEntity, TQuery =
 
   public abstract getEndpoint(): string;
 
-  public getAll(query?: Partial<TQuery> | PaginationRequest): Observable<TEntity[]> {
+  public getAll(query?: Partial<TQuery>): Observable<TEntity[]> {
     const endpoint = this._endpoint;
     return this._http.get<TEntity[]>(
       query ? this._createQueryEndpoint(endpoint, query) : endpoint
     );
+  }
+
+  public getAllPaged(paginationRequest: PaginationRequest, query?: Partial<TQuery>): Observable<PaginationResponse<TEntity>> {
+    const endpoint = this._endpoint;
+    const mergedQuery = merge(paginationRequest, query ?? {});
+    return this._http.get<PaginationResponse<TEntity>>(this._createQueryEndpoint(endpoint, mergedQuery));
   }
 
   public getSingle(id: string, query?: Partial<TQuery>): Observable<TEntity> {

--- a/projects/shared/components/auto-table/components/auto-table/auto-table.component.html
+++ b/projects/shared/components/auto-table/components/auto-table/auto-table.component.html
@@ -51,4 +51,4 @@
   <mat-footer-row [class.d-none]="dataSource.data.length > 0" *matFooterRowDef="['noResults']"></mat-footer-row>
 </mat-table>
 
-<ng-content select="[autoPaginator]"></ng-content>
+<ng-content select="[autoPaginator]" *ngIf="!!autoPaginator?.paginator"></ng-content>

--- a/projects/shared/components/auto-table/components/auto-table/auto-table.component.html
+++ b/projects/shared/components/auto-table/components/auto-table/auto-table.component.html
@@ -3,6 +3,7 @@
   auto-table
   matSort
   [dataSource]="dataSource"
+  (matSortChange)="sorted($event)"
 >
   <ng-container [matColumnDef]="column.property" *ngFor="let column of columnDefs">
     <ng-container *ngIf="column.sortable then sortableHeader else defaultHeader"></ng-container>

--- a/projects/shared/components/auto-table/components/auto-table/auto-table.component.ts
+++ b/projects/shared/components/auto-table/components/auto-table/auto-table.component.ts
@@ -73,7 +73,9 @@ export class AutoTableComponent implements OnChanges, AfterContentInit, AfterVie
   }
 
   ngAfterContentInit(): void {
-    this.dataSource.paginator = this.autoPaginator?.paginator ?? this.dataSource.paginator;
+    if (!!this.autoPaginator?.paginator && !this.autoPaginator?.controlManually) {
+      this.dataSource.paginator = this.autoPaginator.paginator;
+    }
 
     if (this.autoColumnDefs) {
       this._refreshColumns(this.autoColumnDefs.toArray());

--- a/projects/shared/components/auto-table/directives/auto-paginator.directive.ts
+++ b/projects/shared/components/auto-table/directives/auto-paginator.directive.ts
@@ -1,10 +1,13 @@
-import { ContentChild, Directive } from '@angular/core';
+import { Directive, Inject, Input, Optional } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 
 @Directive({
-  selector: '[autoPaginator]'
+  selector: '[autoPaginator]',
+  exportAs: 'autoPaginator'
 })
 export class AutoPaginatorDirective {
-  @ContentChild(MatPaginator)
-  paginator: MatPaginator | undefined;
+  @Input()
+  controlManually = false;
+
+  constructor(@Inject(MatPaginator) @Optional() readonly paginator: MatPaginator) {}
 }


### PR DESCRIPTION
## Changes

- Added support to override default paginator functionality for `AutoTableComponent` and `AutoPaginatorDirective`
- Added support for custom sorting to `AutoTableComponent`
- Added `PaginationRequest` and `PaginationResponse` models to match API
- Updated `AbstractEntityService` and `AbstractQueryableEntityService` to support new pagination models
- Adjusted `AdminDataTableComponent` to use and support new functionality from `AutoTableComponent`
- Implemented pagination via API on all admin pages
  - Implemented a cache to help reduce number of API calls
  - Adjusted sort behavior to also sort data via API

Closes #17 
Closes #18 