### PR TITLE
Added Photograph to Genus & Specimen Related Pages

### DIFF
--- a/projects/app/src/app/features/genus/models/genus.model.ts
+++ b/projects/app/src/app/features/genus/models/genus.model.ts
@@ -25,3 +25,12 @@ export class Genus implements IGenus {
     this.specimens = model?.specimens;
   }
 }
+
+export class GenusDisplay extends Genus {
+  public documentUri: string | undefined;
+
+  constructor(model?: Partial<Genus>, documentUri?: string | undefined) {
+    super(model);
+    this.documentUri = documentUri;
+  }
+}

--- a/projects/app/src/app/features/specimen/models/specimen.model.ts
+++ b/projects/app/src/app/features/specimen/models/specimen.model.ts
@@ -156,3 +156,12 @@ export class Specimen implements ISpecimen {
     this.setea = model?.setea;
   }
 }
+
+export class SpecimenDisplay extends Specimen {
+  public documentUri: string | undefined;
+
+  constructor(model?: Partial<ISpecimen>, documentUri?: string) {
+    super(model);
+    this.documentUri = documentUri;
+  }
+}

--- a/projects/app/src/app/features/specimen/models/specimen.model.ts
+++ b/projects/app/src/app/features/specimen/models/specimen.model.ts
@@ -1,4 +1,4 @@
-import { IGenus, IPhotograph } from '@app/features';
+import { Genus, GenusDisplay, IGenus, IPhotograph } from '@app/features';
 import { IEntity } from '@core/models/entity';
 
 import { SpecimenEyes } from './specimen-eyes.model';
@@ -158,6 +158,7 @@ export class Specimen implements ISpecimen {
 }
 
 export class SpecimenDisplay extends Specimen {
+  public genus: Genus | GenusDisplay | undefined;
   public documentUri: string | undefined;
 
   constructor(model?: Partial<ISpecimen>, documentUri?: string) {

--- a/projects/app/src/app/pages/filter/pages/filter-result/filter-result.component.html
+++ b/projects/app/src/app/pages/filter/pages/filter-result/filter-result.component.html
@@ -3,12 +3,12 @@
 </div>
 
 <ng-container *ngIf="specimen$ | async as specimen">
-  <div class="my-3 d-flex align-items-center justify-content-center flex-wrap">
+  <div class="my-3 d-flex align-items-center justify-content-center flex-wrap" *ngIf="!!specimen.documentUri">
     <img
       style="width: 40%"
       class="img-fluid mx-auto d-block border rounded"
-      src="/assets/annotated_cope_cropped.jpg"
       alt="Specimen Image"
+      [src]="specimen.documentUri"
     />
   </div>
 

--- a/projects/app/src/app/pages/info/components/specimen-card/specimen-card.component.html
+++ b/projects/app/src/app/pages/info/components/specimen-card/specimen-card.component.html
@@ -6,10 +6,16 @@
         <br />
         <span>({{ specimen.gender === enumSpecimenGender.Male ? 'Male' : 'Female' }})</span>
       </h2>
+
+      <!-- Genus Photo -->
+
+
+      <!-- Specimen Photo -->
       <img
-        class="img-fluid mx-auto d-block border rounded"
-        src="/assets/annotated_cope_cropped.jpg"
+        class="my-1 img-fluid mx-auto d-block border rounded"
         alt="Specimen Photo"
+        [src]="$any(specimen).documentUri"
+        *ngIf="!!$any(specimen).documentUri"
       />
     </div>
     <div class="col-lg py-2">

--- a/projects/app/src/app/pages/info/components/specimen-card/specimen-card.component.html
+++ b/projects/app/src/app/pages/info/components/specimen-card/specimen-card.component.html
@@ -8,7 +8,12 @@
       </h2>
 
       <!-- Genus Photo -->
-
+      <img
+        class="my-1 img-fluid mx-auto d-block border rounded"
+        alt="Genus Photo"
+        [src]="$any(specimen).genus.documentUri"
+        *ngIf="!!$any(specimen).genus?.documentUri"
+      />
 
       <!-- Specimen Photo -->
       <img

--- a/projects/app/src/app/pages/info/components/specimen-card/specimen-card.component.ts
+++ b/projects/app/src/app/pages/info/components/specimen-card/specimen-card.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
-import { Specimen, SpecimenGender } from '@app/features';
+import { Specimen, SpecimenDisplay, SpecimenGender } from '@app/features';
 
 @Component({
   selector: 'app-specimen-card',
@@ -14,5 +14,5 @@ export class SpecimenCardComponent {
   readonly enumSpecimenGender: typeof SpecimenGender = SpecimenGender;
 
   @Input()
-  specimen: Specimen | undefined;
+  specimen: Specimen | SpecimenDisplay | undefined;
 }

--- a/projects/app/src/app/pages/info/pages/info-single/info-single.component.ts
+++ b/projects/app/src/app/pages/info/pages/info-single/info-single.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject, Subject, takeUntil } from 'rxjs';
+import { BehaviorSubject, map, mergeMap, Observable, of, Subject, takeUntil } from 'rxjs';
 
-import { Specimen, SpecimenService } from '@app/features';
+import { DocumentService, Specimen, SpecimenDisplay, SpecimenService } from '@app/features';
 
 @Component({
   selector: 'app-info-single',
@@ -10,24 +10,29 @@ import { Specimen, SpecimenService } from '@app/features';
   host: {
     'class': 'd-block'
   },
-  providers: [SpecimenService],
+  providers: [DocumentService, SpecimenService],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class InfoSinglePageComponent implements OnInit, OnDestroy {
   private readonly _destroyed = new Subject<void>();
 
-  private readonly _specimenSubject = new BehaviorSubject<Specimen | undefined>(undefined);
+  private readonly _specimenSubject = new BehaviorSubject<SpecimenDisplay | undefined>(undefined);
   readonly specimen$ = this._specimenSubject.asObservable();
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
+    private readonly _documentService: DocumentService,
     private readonly _specimenService: SpecimenService,
     private readonly _router: Router
   ) {
     this.specimen$ = this.specimen$.pipe(takeUntil(this._destroyed));
 
     const specimenResult: Specimen = this._router.getCurrentNavigation()?.extras.state?.result;
-    if (!!specimenResult) this._specimenSubject.next(specimenResult);
+    if (!!specimenResult) {
+      this._getSpecimenPhotoUri$(specimenResult).subscribe({
+        next: result => this._specimenSubject.next(result)
+      });
+    }
   }
 
   ngOnInit(): void {
@@ -36,10 +41,22 @@ export class InfoSinglePageComponent implements OnInit, OnDestroy {
       if (!!id) {
         this._specimenService.getSingle(id, {
           include: ['genus', 'photograph']
-        }).subscribe({
-          next: specimen => this._specimenSubject.next(specimen)
+        }).pipe(
+          mergeMap(result => this._getSpecimenPhotoUri$(result))
+        ).subscribe({
+          next: result => this._specimenSubject.next(result)
         });
       }
+    }
+  }
+
+  private _getSpecimenPhotoUri$(model: Specimen | SpecimenDisplay): Observable<SpecimenDisplay> {
+    if (!!model.photograph?.documentId) {
+      return this._documentService.getDocumentUri(model.photograph.documentId).pipe(
+        map(result => new SpecimenDisplay(model, result))
+      );
+    } else {
+      return of(new SpecimenDisplay(model, undefined));
     }
   }
 

--- a/projects/app/src/app/pages/info/pages/info/info.component.ts
+++ b/projects/app/src/app/pages/info/pages/info/info.component.ts
@@ -29,7 +29,8 @@ export class InfoPageComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this._specimenService.getAll({
-      include: ['genus', 'photograph']
+      include: ['genus', 'photograph'],
+      orderBy: ['genus.name']
     }).pipe(
       map(specimens => specimens.sort((a, b) => a.genus!.name! > b.genus!.name! ? 1 : -1))
     ).subscribe({


### PR DESCRIPTION
## Changes

- Created `SpecimenDisplay` and `GenusDisplay` models that extend their perspective base models and added a `documentUri` property that is used in the `src` attribute of `<img>` elements
- Adjusted template to `SpecimenCardComponent` to display the Genus photo and Specimen photo
- Added Genus and Specimen photos to the `FilterResultPageComponent`, `InfoPageComponent`, and `InfoSinglePageComponent`

Closes #29 