### PR TITLE
Fixed Admin Column Sorting Bug

### DIFF
--- a/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-contributors/admin-contributors-manage/admin-contributors-manage.component.ts
@@ -34,7 +34,7 @@ export class AdminContributorsManageComponent implements IAdminManageView, OnIni
   pageSize = 10;
   cachedData: Contributor[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -51,8 +51,8 @@ export class AdminContributorsManageComponent implements IAdminManageView, OnIni
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: this.sortDirection === 'asc' ? ['name'] : [],
-      orderByDescending: this.sortDirection === 'desc' ? ['name'] : []
+      orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+      orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
     }).subscribe({
       next: results => this._contributorsSubject.next(results)
     });
@@ -114,7 +114,7 @@ export class AdminContributorsManageComponent implements IAdminManageView, OnIni
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-definitions/admin-definitions-manage/admin-definitions-manage.component.ts
@@ -34,7 +34,7 @@ export class AdminDefinitionsManageComponent implements IAdminManageView, OnInit
   pageSize = 10;
   cachedData: Definition[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -51,8 +51,8 @@ export class AdminDefinitionsManageComponent implements IAdminManageView, OnInit
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: this.sortDirection === 'asc' ? ['name'] : [],
-      orderByDescending: this.sortDirection === 'desc' ? ['name'] : []
+      orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+      orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
     }).subscribe({
       next: results => this._definitionsSubject.next(results)
     });
@@ -114,7 +114,7 @@ export class AdminDefinitionsManageComponent implements IAdminManageView, OnInit
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-documents/admin-documents-manage/admin-documents-manage.component.ts
@@ -33,7 +33,7 @@ export class AdminDocumentsManageComponent implements IAdminManageView, OnInit, 
   pageSize = 10;
   cachedData: Document[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -50,8 +50,8 @@ export class AdminDocumentsManageComponent implements IAdminManageView, OnInit, 
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: this.sortDirection === 'asc' ? ['name'] : [],
-      orderByDescending: this.sortDirection === 'desc' ? ['name'] : []
+      orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+      orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
     }).subscribe({
       next: results => this._documentsSubject.next(results)
     });
@@ -119,7 +119,7 @@ export class AdminDocumentsManageComponent implements IAdminManageView, OnInit, 
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage-properties/admin-filter-models-manage-properties.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage-properties/admin-filter-models-manage-properties.component.ts
@@ -34,7 +34,7 @@ export class AdminFilterModelsManagePropertiesComponent implements IAdminManageV
   pageSize = 10;
   cachedData: FilterModelProperty[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   filterModelId: string | undefined;
 
@@ -56,8 +56,8 @@ export class AdminFilterModelsManagePropertiesComponent implements IAdminManageV
     if (!!this.filterModelId) {
       this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
         filterModelId: [this.filterModelId],
-        orderBy: this.sortDirection === 'asc' ? ['propertyName'] : [],
-        orderByDescending: this.sortDirection === 'desc' ? ['propertyName'] : []
+        orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+        orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
       }).subscribe({
         next: results => this._filterModelPropertiesSubject.next(results)
       });
@@ -117,7 +117,7 @@ export class AdminFilterModelsManagePropertiesComponent implements IAdminManageV
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage/admin-filter-models-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filter-models/admin-filter-models-manage/admin-filter-models-manage.component.ts
@@ -33,7 +33,7 @@ export class AdminFilterModelsManageComponent implements IAdminManageView, OnIni
   pageSize = 10;
   cachedData: FilterModel[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -50,8 +50,8 @@ export class AdminFilterModelsManageComponent implements IAdminManageView, OnIni
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: this.sortDirection === 'asc' ? ['typeName'] : [],
-      orderByDescending: this.sortDirection === 'desc' ? ['typeName'] : []
+      orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+      orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
     }).subscribe({
       next: results => this._filterModelsSubject.next(results)
     });
@@ -114,7 +114,7 @@ export class AdminFilterModelsManageComponent implements IAdminManageView, OnIni
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-manage/admin-filter-sections-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-manage/admin-filter-sections-manage.component.ts
@@ -36,7 +36,7 @@ export class AdminFiltersSectionsManageComponent implements IAdminManageView, On
   pageSize = 10;
   cachedData: FilterSection[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   filterId: string | undefined;
 
@@ -58,8 +58,8 @@ export class AdminFiltersSectionsManageComponent implements IAdminManageView, On
     if (!!this.filterId) {
       this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
         filterId: [this.filterId],
-        orderBy: this.sortDirection === 'asc' ? ['order'] : [],
-        orderByDescending: this.sortDirection === 'desc' ? ['order'] : []
+        orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+        orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
       }).subscribe({
         next: results => this._filterSectionsSubject.next(results)
       });
@@ -123,7 +123,7 @@ export class AdminFiltersSectionsManageComponent implements IAdminManageView, On
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-manage/admin-filter-sections-parts-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-manage/admin-filter-sections-parts-manage.component.ts
@@ -36,7 +36,7 @@ export class AdminFiltersSectionsPartsManageComponent implements IAdminManageVie
   pageSize = 10;
   cachedData: FilterSectionPart[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   filterSectionId: string | undefined;
 
@@ -59,8 +59,8 @@ export class AdminFiltersSectionsPartsManageComponent implements IAdminManageVie
       this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
         filterSectionId: [this.filterSectionId],
         include: ['filterModelProperty'],
-        orderBy: this.sortDirection === 'asc' ? ['order'] : [],
-        orderByDescending: this.sortDirection === 'desc' ? ['order'] : []
+        orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+        orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
       }).subscribe({
         next: results => this._filterSectionPartsSubject.next(results)
       });
@@ -124,7 +124,7 @@ export class AdminFiltersSectionsPartsManageComponent implements IAdminManageVie
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-options-manage/admin-filter-sections-parts-options-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filter-sections-parts-options-manage/admin-filter-sections-parts-options-manage.component.ts
@@ -37,7 +37,7 @@ export class AdminFiltersSectionsPartsOptionsManageComponent implements IAdminMa
   pageSize = 10;
   cachedData: FilterSectionPartOption[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   filterSectionPartId: string | undefined;
 
@@ -59,8 +59,8 @@ export class AdminFiltersSectionsPartsOptionsManageComponent implements IAdminMa
     if (!!this.filterSectionPartId) {
       this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
         filterSectionPartId: [this.filterSectionPartId],
-        orderBy: this.sortDirection === 'asc' ? ['order'] : [],
-        orderByDescending: this.sortDirection === 'desc' ? ['order'] : []
+        orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+        orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
       }).subscribe({
         next: results => this._filterSectionPartOptionsSubject.next(results)
       });
@@ -120,7 +120,7 @@ export class AdminFiltersSectionsPartsOptionsManageComponent implements IAdminMa
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-filters/admin-filters-manage/admin-filters-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-filters/admin-filters-manage/admin-filters-manage.component.ts
@@ -34,7 +34,7 @@ export class AdminFiltersManageComponent implements IAdminManageView, OnInit, On
   pageSize = 10;
   cachedData: Filter[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -52,8 +52,8 @@ export class AdminFiltersManageComponent implements IAdminManageView, OnInit, On
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
       include: ['filterModel'],
-      orderBy: this.sortDirection === 'asc' ? ['displayName'] : [],
-        orderByDescending: this.sortDirection === 'desc' ? ['displayName'] : []
+      orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+      orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
     }).subscribe({
       next: results => this._filtersSubject.next(results)
     });
@@ -116,7 +116,7 @@ export class AdminFiltersManageComponent implements IAdminManageView, OnInit, On
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-genuses/admin-genuses-manage/admin-genuses-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-genuses/admin-genuses-manage/admin-genuses-manage.component.ts
@@ -34,7 +34,7 @@ export class AdminGenusesManageComponent implements IAdminManageView, OnInit, On
   pageSize = 10;
   cachedData: Genus[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -53,8 +53,8 @@ export class AdminGenusesManageComponent implements IAdminManageView, OnInit, On
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
       include: ['photograph'],
-      orderBy: this.sortDirection === 'asc' ? ['name'] : [],
-      orderByDescending: this.sortDirection === 'desc' ? ['name'] : []
+      orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+      orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
     }).subscribe({
       next: results => this._genusesSubject.next(results)
     });
@@ -124,7 +124,7 @@ export class AdminGenusesManageComponent implements IAdminManageView, OnInit, On
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-photographs/admin-photographs-manage/admin-photographs-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-photographs/admin-photographs-manage/admin-photographs-manage.component.ts
@@ -35,7 +35,7 @@ export class AdminPhotographsManageComponent implements IAdminManageView, OnInit
   pageSize = 10;
   cachedData: Photograph[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -54,8 +54,8 @@ export class AdminPhotographsManageComponent implements IAdminManageView, OnInit
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
       include: ['document'],
-      orderBy: this.sortDirection === 'asc' ? ['title'] : [],
-      orderByDescending: this.sortDirection === 'desc' ? ['title'] : []
+      orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+      orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
     }).subscribe({
       next: results => this._photographsSubject.next(results)
     });
@@ -123,7 +123,7 @@ export class AdminPhotographsManageComponent implements IAdminManageView, OnInit
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-references/admin-references-manage/admin-references-manage.component.ts
@@ -33,7 +33,7 @@ export class AdminReferencesManageComponent implements IAdminManageView, OnInit,
   pageSize = 10;
   cachedData: Reference[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -50,8 +50,8 @@ export class AdminReferencesManageComponent implements IAdminManageView, OnInit,
 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
-      orderBy: this.sortDirection === 'asc' ? ['content'] : [],
-      orderByDescending: this.sortDirection === 'desc' ? ['content'] : []
+      orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+      orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
     }).subscribe({
       next: results => this._referencesSubject.next(results)
     });
@@ -113,7 +113,7 @@ export class AdminReferencesManageComponent implements IAdminManageView, OnInit,
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 

--- a/projects/app/src/app/pages/admin/pages/admin-specimens/admin-specimens-manage/admin-specimens-manage.component.ts
+++ b/projects/app/src/app/pages/admin/pages/admin-specimens/admin-specimens-manage/admin-specimens-manage.component.ts
@@ -34,7 +34,7 @@ export class AdminSpecimensManageComponent implements IAdminManageView, OnInit, 
   pageSize = 10;
   cachedData: Specimen[][] = [];
   get pageCount(): number { return Math.ceil(this.paginatorLength / this.pageSize); }
-  sortDirection: 'asc' | 'desc' | undefined;
+  sort?: Sort = undefined;
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
@@ -53,8 +53,8 @@ export class AdminSpecimensManageComponent implements IAdminManageView, OnInit, 
   getEntities(refreshCache: boolean = false): void {
     this._getPagedEntities$(this.pageIndex, this.pageSize, refreshCache, {
       include: ['genus', 'photograph'],
-      orderBy: this.sortDirection === 'asc' ? ['genus.name'] : [],
-      orderByDescending: this.sortDirection === 'desc' ? ['genus.name'] : []
+      orderBy: this.sort?.direction === 'asc' ? [this.sort.active] : [],
+      orderByDescending: this.sort?.direction === 'desc' ? [this.sort.active] : []
     }).subscribe({
       next: results => this._specimensSubject.next(results)
     });
@@ -124,7 +124,7 @@ export class AdminSpecimensManageComponent implements IAdminManageView, OnInit, 
   }
 
   sortChange(sort: Sort): void {
-    this.sortDirection = sort.direction !== '' ? sort.direction : undefined;
+    this.sort = sort.direction !== '' ? sort : undefined;
     this.getEntities(true);
   }
 


### PR DESCRIPTION
Fixed a bug where admin columns would order by a single hard-coded column name that was sent to the pagination API, rather than the name of the column clicked.

Closes #27 